### PR TITLE
Fix travis testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.gch
 gen.rs
+.vagga

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
-sudo: false
+sudo: required
+dist: trusty
 language: rust
-cache: cargo
-rust:
-- stable
-- beta
-- nightly
-os:
-- linux
+cache:
+    directories:
+        - .vagga
+
 env:
   matrix:
+  - FEATURES=""
   - FEATURES="static"
   - FEATURES="wayland"
   - FEATURES="render"
@@ -22,69 +21,44 @@ env:
   - FEATURES="static render wayland"
   - FEATURES="static render serialization"
   - FEATURES="static wayland serialization"
+  - FEATURES="render wayland serialization"
   - FEATURES="static render wayland serialization"
   global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=""
   - secure: LfrkRn+N3DVHLHuVFX1RB2clpfQ6IwipiRRwB0Kg7ARM/rMhS5L3kM98PUQ5u+X3mgfxn93whAHtIh3S4oNQOWYMgYBYPNaFaGbV4zkEeKyAvU5cl8AzAuyH+hSx/x/njh8A0Z2Ki90lM/8rPHuU4VIudcunR9WvUkbwglRfZfcfQZY/I5PJ2rwWNBvsYopMv1o2kU0oFqEm89MIL6H7WpH02w1oWDiE+EQAQDYEsoqcxJayblNkikSLEH1zJouP5F1exN6j5gsnapHr2bVDBGNw9o6He5idK3iMaUaFjtqgDF+/Wlci1v1+FnQnX11691aR1pzpBA3KrQry8IeLtR6s7THWnr6/zWRbqKGzhN6mXGHy/yWPlg+ade2333i6qHa/KxQDvt7/S1mSBtwtvCgr7VIMLo5C3n7TDY0H0+WkjlqVQz2iIB272OOGct6XQkjoG1V3xWm2DjjQo4GVT619DsF8ZiMTeJUD86Rix5kLu9XVvxlIHey7EQwM838e2r9U+a3XdQPixkTV4c9zZnE+t3ZyHSMdIUu2GFNfgjyCHBtj80f1E42npIPFp6JSEbBcvkqpp4ggRAuFMOrmdD79YvGDPXEp9GshXUvnZ6X0c/mN5Cfro9JvPGkC6fmKRMP+RZW7WpWvIpJuO91FL+6xFIlZmq5yQBPROx22FTE=
+
 before_script:
+- "echo ubuntu-mirror: http://mirrors.us.kernel.org/ubuntu/ > ~/.vagga.yaml"
+- "echo alpine-mirror: http://mirrors.gigenet.com/alpinelinux/ >> ~/.vagga.yaml"
 - |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
-- "(cargo install rustfmt || true)"
-- "(cargo install clippy || true)"
-- wget https://github.com/Cloudef/wlc/releases/download/v0.0.7/wlc-0.0.7.tar.bz2 -O
-  /tmp/wlc.tar.bz2
-- cd /tmp/; tar -xvf /tmp/wlc.tar.bz2
-- cd /tmp/wlc; cmake -DCMAKE_BUILD_TYPE=Release -DSOURCE_WLPROTOP=ON -DCMAKE_INSTALL_LIBDIR=/usr/lib
-  -DCMAKE_INSTALL_PREFIX=/usr
+    echo "$(id -un):100000:65536" | sudo tee /etc/subuid | sudo tee /etc/subgid
+    sudo apt-get install uidmap -y
+    curl http://files.zerogw.com/vagga/vagga-install-testing.sh | sh
+
 script:
+- vagga check-fmt
+- vagga clippy "$FEATURES"
 - |
-  if [ $TRAVIS_RUST_VERSION != "nightly" ]
-  then
-      export FEATURES="unsafe-stable $FEATURES"
-  done
-  travis-cargo fmt -- --write-mode=diff &&
-  travis-cargo build --features $FEATURES &&
-  travis-cargo test --features $FEATURES &&
-  travis-cargo clippy --features $FEATURES
-  if [ $FEATURES == "static render wayland serialization" ]
-  then
-      travis-cargo doc --only nightly
-  done
+    if [[ $FEATURES != *"serialization"* ]]; then
+        vagga build-stable "unsafe-stable $FEATURES"
+        vagga build-example-stable "unsafe-stable $FEATURES"
+        vagga test-stable "unsafe-stable $FEATURES"
+    fi
+
+- vagga build-beta "unsafe-stable $FEATURES"
+- vagga build-example-beta "unsafe-stable $FEATURES"
+- vagga test-beta "unsafe-stable $FEATURES"
+- vagga build-nightly "$FEATURES"
+- vagga build-example-nightly "$FEATURES"
+- vagga test-nightly "$FEATURES"
+- |
+    if [ "$FEATURES" == "static render wayland serialization" ]
+    then
+      vagga doc "$FEATURES"
+    fi
+
 after_success:
 - |
-  if [ $FEATURES == "static render wayland serialization" ]
-  then
-      travis-cargo --only nightly doc-upload
-  done
-addons:
-  apt:
-    packages:
-    - build-essential
-    - pkg-config
-    - clang
-    - libclang-dev
-    - gcc-multilib
-    - cmake
-    - libpixman-1-dev
-    - libwayland-dev
-    - libxkbcommon-dev
-    - udev
-    - libinput-dev
-    - libx11-dev
-    - libxfixes-dev
-    - libx11-xcb-dev
-    - libxcb-ewmh-dev
-    - libxcb-composite0-dev
-    - libxcb-xkb-dev
-    - libxcb-xfixes0-dev
-    - libxcb-image0-dev
-    - libgbm-dev
-    - libdrm-dev
-    - libegl1-mesa-dev
-    - libgles2-mesa-dev
-    - libdbus-1-dev
-    - libsystemd-dev
-    - libcurl4-openssl-dev
-    - libelf-dev
-    - libdw-dev
+    if [ $FEATURES == "static render wayland serialization" ]
+    then
+      vagga doc-upload $TRAVIS_BRANCH $TRAVIS_REPO_SLUG $TRAVIS_PULL_REQUEST $GH_TOKEN
+    fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [wlc](https://github.com/Cloudef/wlc) Bindings for Rust [![Build Status](https://travis-ci.org/Drakulix/wlc.svg?branch=master)](https://travis-ci.org/Drakulix/wlc) [![Crates.io](https://img.shields.io/crates/v/wlc.svg)](https://crates.io/crates/simplelog) [![Crates.io](https://img.shields.io/crates/l/wlc.svg)](https://crates.io/crates/simplelog) [![](https://tokei.rs/github/Drakulix/wlc)](https://github.com/Aaronepower/tokei)
+# [wlc](https://github.com/Cloudef/wlc) Bindings for Rust [![Build Status](https://travis-ci.org/Drakulix/wlc.svg?branch=master)](https://travis-ci.org/Drakulix/wlc) [![Crates.io](https://img.shields.io/crates/v/wlc.svg)](https://crates.io/crates/simplelog) [![Crates.io](https://img.shields.io/crates/l/wlc.svg)](https://crates.io/crates/simplelog) [![](https://tokei.rs/b1/github/Drakulix/wlc)](https://github.com/Aaronepower/tokei)
 
 Completely safe and idiomatic bindings to the wayland compositor library.
 

--- a/vagga.yaml
+++ b/vagga.yaml
@@ -1,0 +1,176 @@
+minimum-vagga: v0.5.0
+
+_cmds:
+    build: &build-cmd |
+        rustup update
+        if [ -z "$@" ]; then
+            cargo build
+        else
+            cargo build --features "$@"
+        fi
+    build-example: &build-example-cmd |
+        rustup update
+        if [ -z "$@" ]; then
+            cargo build --example example
+        else
+            cargo build --example example --features "$@"
+        fi
+    test: &test-cmd |
+        rustup update
+        if [ -z "$@" ]; then
+            cargo test
+        else
+            cargo test --features "$@"
+        fi
+
+
+containers:
+    base:
+        auto-clean: true
+        setup:
+            - !Ubuntu xenial
+            - !UbuntuUniverse
+            - !Install [build-essential, wget, curl, pkg-config, file, openssl, sudo, ca-certificates, gcc-multilib, clang, libclang-dev, cmake, git, libpixman-1-dev, libwayland-dev, libxkbcommon-dev, udev, libinput-dev, libx11-dev, libxfixes-dev, libx11-xcb-dev, libxcb-ewmh-dev, libxcb-composite0-dev, libxcb-xkb-dev, libxcb-xfixes0-dev, libxcb-image0-dev, libgbm-dev, libdrm-dev, libgl1-mesa-dev, libegl1-mesa-dev, libgles2-mesa-dev, libdbus-1-dev, libsystemd-dev, libcurl4-openssl-dev, libelf-dev, libdw-dev, wayland-protocols, linux-libc-dev]
+            - !PipConfig
+              dependencies: true
+            - !Py2Install [travis-cargo==0.1.15]
+            - !Sh |
+                cd /tmp/
+                git clone git://github.com/Cloudef/wlc
+                cd wlc;
+                git submodule update --init --recursive
+                mkdir target && cd target
+                cmake -DCMAKE_BUILD_TYPE=Release -DSOURCE_WLPROTO=ON -DCMAKE_INSTALL_LIBDIR=/usr/lib -DCMAKE_INSTALL_PREFIX=/usr ..
+                make
+                make install
+                cd ..
+                rm -rf wlc
+    stable:
+        auto-clean: true
+        environ:
+            HOME: /work/.vagga/stable-home
+            PATH: /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/work/.vagga/stable-home/.cargo/bin:/work/.vagga/stable-home/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/
+        setup:
+            - !Container base
+            - !Env HOME: /work/.vagga/stable-home
+            - !Sh rm -rf $HOME/.rustup $HOME/.cargo
+            - !Sh curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host x86_64-unknown-linux-gnu --default-toolchain stable --no-modify-path
+            - !Env PATH: /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/work/.vagga/stable-home/.cargo/bin
+            - !Sh cargo install --git https://github.com/hecal3/cargo-install-upgrade
+            - !Sh cargo install rustfmt
+    beta:
+        auto-clean: true
+        environ:
+            HOME: /work/.vagga/beta-home
+            PATH: /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/work/.vagga/beta-home/.cargo/bin:/work/.vagga/beta-home/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/bin/
+        setup:
+            - !Container base
+            - !Env HOME: /work/.vagga/beta-home
+            - !Sh rm -rf $HOME/.rustup $HOME/.cargo
+            - !Sh curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host x86_64-unknown-linux-gnu --default-toolchain beta --no-modify-path
+    nightly:
+        auto-clean: true
+        environ:
+            HOME: /work/.vagga/nightly-home
+            PATH: /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/work/.vagga/nightly-home/.cargo/bin:/work/.vagga/nightly-home/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/
+        setup:
+            - !Container base
+            - !Env HOME: /work/.vagga/nightly-home
+            - !Sh rm -rf $HOME/.rustup $HOME/.cargo
+            - !Sh curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host x86_64-unknown-linux-gnu --default-toolchain nightly --no-modify-path
+            - !Env PATH: /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/work/.vagga/nightly-home/.cargo/bin
+            - !Sh cargo install --git https://github.com/hecal3/cargo-install-upgrade
+            - !Sh cargo install clippy
+
+commands:
+    check-fmt: !Command
+        description: Check for wrong formatting
+        container: stable
+        run: |
+                rustup update
+                cargo install-upgrade
+                cargo fmt -- --write-mode=diff
+
+    build-stable: !Command
+        description: Build on rust stable
+        accepts-arguments: true
+        container: stable
+        run: *build-cmd
+    build-beta: !Command
+        description: Build on rust beta
+        accepts-arguments: true
+        container: beta
+        run: *build-cmd
+    build-nightly: !Command
+        description: Build on rust beta
+        accepts-arguments: true
+        container: nightly
+        run: *build-cmd
+
+    test-stable: !Command
+        description: Test on rust stable
+        accepts-arguments: true
+        container: stable
+        run: *test-cmd
+    test-beta: !Command
+        description: Test on rust beta
+        accepts-arguments: true
+        container: beta
+        run: *test-cmd
+    test-nightly: !Command
+        description: Test on rust beta
+        accepts-arguments: true
+        container: nightly
+        run: *test-cmd
+
+    build-example-stable: !Command
+        description: Build the example on rust stable
+        accepts-arguments: true
+        container: stable
+        run: *build-example-cmd
+    build-example-beta: !Command
+        description: Build the example on rust beta
+        accepts-arguments: true
+        container: beta
+        run: *build-example-cmd
+    build-example-nightly: !Command
+        description: Build the example on rust beta
+        accepts-arguments: true
+        container: nightly
+        run: *build-example-cmd
+
+    clippy: !Command
+        description: Run clippy over codebase
+        accepts-arguments: true
+        container: nightly
+        run: |
+                rustup update
+                cargo install-upgrade
+                if [ -z "$@" ]; then
+                    cargo clippy
+                else
+                    cargo clippy --features "$@"
+                fi
+
+    doc: !Command
+        description: Generate documentation
+        accepts-arguments: true
+        container: nightly
+        run: |
+                rustup update
+                if [ -z "$@" ]; then
+                    cargo doc
+                else
+                    cargo doc --features "$@"
+                fi
+
+    doc-upload: !Command
+        description: Upload documentation
+        accepts-arguments: true
+        container: nightly
+        run: |
+            export TRAVIS_BRANCH=$1
+            export TRAVIS_REPO_SLUG=$2
+            export TRAVIS_PULL_REQUEST=$3
+            export GH_TOKEN=$4
+            travis-cargo doc-upload

--- a/wlc-sys/build.rs
+++ b/wlc-sys/build.rs
@@ -78,6 +78,7 @@ fn cmake() {
                 .define("WLC_BUILD_TESTS", "OFF")
                 .build();
 
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());
     println!("cargo:rustc-link-search=native={}/build/protos", dst.display());
     println!("cargo:rustc-link-search=native={}/build/lib/chck/lib", dst.display());

--- a/wlc-sys/src/lib.rs
+++ b/wlc-sys/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types, non_upper_case_globals)]
 
 extern crate libc;
-use libc::*;
+use libc::c_void;
 
 type wl_resource = c_void;
 type wl_client = c_void;


### PR DESCRIPTION
- Add vagga configuration
    - works around travis old (trusty) os environment
    - creates reproducable build environment
- Edit travis conf to install and use vagga for testing